### PR TITLE
handle service and plugins in an idempotent way

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,7 +4,6 @@
     name: "{{ service_name }}.service"
     state: restarted
     daemon_reload: true
-  when: package_state == 'present' and not ansible_check_mode
 
 - name: "restart windows {{ agent_type }} agent"
   win_shell: "Restart-Service -Name {{ service_name }} -Force"

--- a/tasks/linux.yml
+++ b/tasks/linux.yml
@@ -20,6 +20,12 @@
     - 'manager/previous'
     - 'manager/previous/current'
 
+- name: Create service file
+  template:
+    src: "observiq-agent.service"
+    dest: "/etc/systemd/system/{{ service_name }}.service"
+    mode: 0644
+
 - name: Register manager
   stat:
     path: "{{ install_dir }}/manager/current/bpagent-manager-linux-amd64"
@@ -64,7 +70,7 @@
   when: not plugin_dir.stat.exists
   notify:
     - "restart {{ agent_type }} agent"
-    - "install plugins"
+    - "download and install plugins"
 
 # Store configuration options as a json file, changes to
 # this file will trigger an update to remote.yaml
@@ -89,13 +95,3 @@
     dest: "{{ install_dir }}/config/os.yaml"
     mode: 0600
   notify: "restart {{ agent_type }} agent"
-
-- name: Create service file
-  template:
-    src: "observiq-agent.service"
-    dest: "/etc/systemd/system/{{ service_name }}.service"
-    mode: 0644
-  notify: "restart {{ agent_type }} agent"
-
-- name: Start observiq-agent
-  service: name={{ service_name }}.service state=started enabled=yes


### PR DESCRIPTION
- service handling needs to create the file early
- service handling allow all service starts / restarts / reloads to happen using the handler (not a task)
- when plugins are missing, use "download and install plugins" handler directly